### PR TITLE
Updated workflows. Added dbgconf files for the Blinky example.

### DIFF
--- a/.ci/vcpkg-configuration.json
+++ b/.ci/vcpkg-configuration.json
@@ -7,11 +7,11 @@
         }
     ],
     "requires": {
-        "arm:tools/open-cmsis-pack/cmsis-toolbox": "^2.6.0",
-        "arm:tools/arm/mdk-toolbox":" ^1.0.0",
-        "arm:tools/kitware/cmake": "^3.28.4",
-        "arm:tools/ninja-build/ninja": "^1.12.0",
-        "arm:compilers/arm/armclang": "^6.22.0",
+        "arm:tools/open-cmsis-pack/cmsis-toolbox": "^2.9.0",
+        "arm:tools/arm/mdk-toolbox":" ^1.1.0",
+        "arm:tools/kitware/cmake": "^3.31.5",
+        "arm:tools/ninja-build/ninja": "^1.12.1",
+        "arm:compilers/arm/armclang": "^6.24.0",
         "arm:compilers/arm/arm-none-eabi-gcc": "^13.3.1"
     }
 }

--- a/.github/workflows/Test-Examples.yml
+++ b/.github/workflows/Test-Examples.yml
@@ -68,7 +68,7 @@ jobs:
         if: always()
         working-directory: ./CI/Examples/Blinky
         run: |
-          cbuild ./Blinky.csolution.yml --packs --update-rte --packs --toolchain AC6 --rebuild
+          cbuild ./Blinky.csolution.yml --packs --toolchain AC6 --rebuild
 
       - name: Upload Artifact of the Blinky AC6 build
         if: always()

--- a/.github/workflows/Test-Examples.yml
+++ b/.github/workflows/Test-Examples.yml
@@ -62,7 +62,9 @@ jobs:
         working-directory: ./
         run: |
           mkdir -p ./CI/Examples/Blinky
+          shopt -s dotglob  # include dotfiles in wildcards          
           cp -rf ./BSP/Examples/Blinky/* ./CI/Examples/Blinky/
+          shopt -u dotglob  # disable it again
 
       - name: Build Blinky AC6
         if: always()

--- a/.github/workflows/Test-MDK-Middleware-RefApps.yml
+++ b/.github/workflows/Test-MDK-Middleware-RefApps.yml
@@ -82,11 +82,17 @@ jobs:
           mkdir -p ./CI/MW-RefApps/Examples/${{ matrix.solution.dir }}/Board/
           cp -rf ./MDK-Middleware/Examples/* ./CI/MW-RefApps/Examples/
 
+      - name: Replace specific csolution files
+        working-directory: ./
+        run: |
           if [ -e ./.ci/MW-RefApps/Examples/${{ matrix.solution.dir }}/${{ matrix.solution.name }}.csolution.yml ]
           then
              cp -rf ./.ci/MW-RefApps/Examples/${{ matrix.solution.dir }}/${{ matrix.solution.name }}.csolution.yml ./CI/MW-RefApps/Examples/${{ matrix.solution.dir }}/${{ matrix.solution.name }}.csolution.yml
           fi
 
+      - name: Add the board layer to the ${{ matrix.solution.dir }}/${{ matrix.solution.name }}.csolution.yml
+        working-directory: ./
+        run: |
           sed -i "s|target-types:|&\n    - type: $TARGET_BOARD\n      board: $TARGET_BOARD\n      variables:\n        - Board-Layer: \$SolutionDir()\$/Board/Board.clayer.yml|"  ./CI/MW-RefApps/Examples/${{ matrix.solution.dir }}/${{ matrix.solution.name }}.csolution.yml
 
       - name: Update board layer for ${{ matrix.solution.name }} AC6 build test

--- a/Examples/Blinky/.cmsis/Blinky+STM32H743I-EVAL.dbgconf
+++ b/Examples/Blinky/.cmsis/Blinky+STM32H743I-EVAL.dbgconf
@@ -1,0 +1,94 @@
+// File: STM32H742_743_753_750.dbgconf
+// Version: 1.0.0
+// Note: refer to STM32H742, STM32H743/753 and STM32H750 reference manual (RM0433)
+//       refer to STM32H742xI/G STM32H743xI/G datasheets
+//       refer to STM32H753xI datasheet
+//       refer to STM32H750VB STM32H750IB STM32H750XB datasheets
+
+// <<< Use Configuration Wizard in Context Menu >>>
+
+// <h> DBGMCU configuration register (DBGMCU_CR)
+//   <o.28> TRGOEN                   <i> External trigger output enable
+//   <o.8>  DBGSTBY_D3               <i> Allow debug in D3 Standby mode
+//   <o.7>  DBGSTOP_D3               <i> Allow debug in D3 Stop mode
+//   <o.2>  DBGSTBY_D1               <i> Allow D1 domain debug in Standby mode
+//   <o.1>  DBGSTOP_D1               <i> Allow D1 domain debug in Stop mode
+//   <o.0>  DBGSLEEP_D1              <i> Allow D1 domain debug in Sleep mode
+// </h>
+DbgMCU_CR = 0x00000007;
+
+// <h> DBGMCU APB3 peripheral freeze register (DBGMCU_APB3FZ1)
+//                                   <i> Reserved bits must be kept at reset value
+//   <o.6>  WWDG1                    <i> WWDG1 stop in debug
+// </h>
+DbgMCU_APB3_Fz1 = 0x00000000;
+
+// <h> DBGMCU APB1L peripheral freeze register (DBGMCU_APB1LFZ1)
+//                                   <i> Reserved bits must be kept at reset value
+//   <o.23> DBG_I2C3                 <i> I2C3 SMBUS timeout stop in debug
+//   <o.22> DBG_I2C2                 <i> I2C2 SMBUS timeout stop in debug
+//   <o.21> DBG_I2C1                 <i> I2C1 SMBUS timeout stop in debug
+//   <o.9>  DBG_LPTIM1               <i> LPTIM1 stop in debug
+//   <o.8>  DBG_TIM14                <i> TIM14 stop in debug
+//   <o.7>  DBG_TIM13                <i> TIM13 stop in debug
+//   <o.6>  DBG_TIM12                <i> TIM12 stop in debug
+//   <o.5>  DBG_TIM7                 <i> TIM7 stop in debug
+//   <o.4>  DBG_TIM6                 <i> TIM6 stop in debug
+//   <o.3>  DBG_TIM5                 <i> TIM5 stop in debug
+//   <o.2>  DBG_TIM4                 <i> TIM4 stop in debug
+//   <o.1>  DBG_TIM3                 <i> TIM3 stop in debug
+//   <o.0>  DBG_TIM2                 <i> TIM2 stop in debug
+// </h>
+DbgMCU_APB1L_Fz1 = 0x00000000;
+
+// <h> DBGMCU APB2 peripheral freeze register (DBGMCU_APB2FZ1)
+//                                   <i> Reserved bits must be kept at reset value
+//   <o.29> DBG_HRTIM                <i> HRTIM stop in debug
+//   <o.18> DBG_TIM17                <i> TIM17 stop in debug
+//   <o.17> DBG_TIM16                <i> TIM16 stop in debug
+//   <o.16> DBG_TIM15                <i> TIM15 stop in debug
+//   <o.1>  DBG_TIM8                 <i> TIM8 stop in debug
+//   <o.0>  DBG_TIM1                 <i> TIM1 stop in debug
+// </h>
+DbgMCU_APB2_Fz1 = 0x00000000;
+
+// <h> DBGMCU APB4 peripheral freeze register (DBGMCU_APB4FZ1)
+//                                   <i> Reserved bits must be kept at reset value
+//   <o.18> DBG_IIWDG1               <i> Independent watchdog for D1 stop in debug
+//   <o.16> DBG_RTC                  <i> RTC stop in debug
+//   <o.12> DBG_LPTIM5               <i> LPTIM5 stop in debug
+//   <o.11> DBG_LPTIM4               <i> LPTIM4 stop in debug
+//   <o.10> DBG_LPTIM3               <i> LPTIM2 stop in debug
+//   <o.9>  DBG_LPTIM2               <i> LPTIM2 stop in debug
+//   <o.7>  DBG_I2C4                 <i> I2C4 SMBUS timeout stop in debug
+// </h>
+DbgMCU_APB4_Fz1 = 0x00000000;
+
+// <h> TPIU Pin Routing (TRACECLK fixed on Pin PE2)
+//   <i> TRACECLK: Pin PE2
+//   <o1> TRACED0
+//     <i> ETM Trace Data 0
+//       <0x00040003=> Pin PE3
+//       <0x00020001=> Pin PC1
+//       <0x0006000D=> Pin PG13
+//   <o2> TRACED1
+//     <i> ETM Trace Data 1
+//       <0x00040004=> Pin PE4
+//       <0x00020008=> Pin PC8
+//       <0x0006000E=> Pin PG14
+//   <o3> TRACED2
+//     <i> ETM Trace Data 2
+//       <0x00040005=> Pin PE5
+//       <0x00030002=> Pin PD2
+//   <o4> TRACED3
+//     <i> ETM Trace Data 3
+//       <0x00040006=> Pin PE6
+//       <0x0002000C=> Pin PC12
+// </h>
+TraceClk_Pin = 0x00040002;
+TraceD0_Pin  = 0x00040003;
+TraceD1_Pin  = 0x00040004;
+TraceD2_Pin  = 0x00040005;
+TraceD3_Pin  = 0x00040006;
+
+// <<< end of configuration section >>>

--- a/Examples/Blinky/.cmsis/Blinky+STM32H743I-EVAL.dbgconf.base@1.1.0
+++ b/Examples/Blinky/.cmsis/Blinky+STM32H743I-EVAL.dbgconf.base@1.1.0
@@ -1,0 +1,94 @@
+// File: STM32H742_743_753_750.dbgconf
+// Version: 1.0.0
+// Note: refer to STM32H742, STM32H743/753 and STM32H750 reference manual (RM0433)
+//       refer to STM32H742xI/G STM32H743xI/G datasheets
+//       refer to STM32H753xI datasheet
+//       refer to STM32H750VB STM32H750IB STM32H750XB datasheets
+
+// <<< Use Configuration Wizard in Context Menu >>>
+
+// <h> DBGMCU configuration register (DBGMCU_CR)
+//   <o.28> TRGOEN                   <i> External trigger output enable
+//   <o.8>  DBGSTBY_D3               <i> Allow debug in D3 Standby mode
+//   <o.7>  DBGSTOP_D3               <i> Allow debug in D3 Stop mode
+//   <o.2>  DBGSTBY_D1               <i> Allow D1 domain debug in Standby mode
+//   <o.1>  DBGSTOP_D1               <i> Allow D1 domain debug in Stop mode
+//   <o.0>  DBGSLEEP_D1              <i> Allow D1 domain debug in Sleep mode
+// </h>
+DbgMCU_CR = 0x00000007;
+
+// <h> DBGMCU APB3 peripheral freeze register (DBGMCU_APB3FZ1)
+//                                   <i> Reserved bits must be kept at reset value
+//   <o.6>  WWDG1                    <i> WWDG1 stop in debug
+// </h>
+DbgMCU_APB3_Fz1 = 0x00000000;
+
+// <h> DBGMCU APB1L peripheral freeze register (DBGMCU_APB1LFZ1)
+//                                   <i> Reserved bits must be kept at reset value
+//   <o.23> DBG_I2C3                 <i> I2C3 SMBUS timeout stop in debug
+//   <o.22> DBG_I2C2                 <i> I2C2 SMBUS timeout stop in debug
+//   <o.21> DBG_I2C1                 <i> I2C1 SMBUS timeout stop in debug
+//   <o.9>  DBG_LPTIM1               <i> LPTIM1 stop in debug
+//   <o.8>  DBG_TIM14                <i> TIM14 stop in debug
+//   <o.7>  DBG_TIM13                <i> TIM13 stop in debug
+//   <o.6>  DBG_TIM12                <i> TIM12 stop in debug
+//   <o.5>  DBG_TIM7                 <i> TIM7 stop in debug
+//   <o.4>  DBG_TIM6                 <i> TIM6 stop in debug
+//   <o.3>  DBG_TIM5                 <i> TIM5 stop in debug
+//   <o.2>  DBG_TIM4                 <i> TIM4 stop in debug
+//   <o.1>  DBG_TIM3                 <i> TIM3 stop in debug
+//   <o.0>  DBG_TIM2                 <i> TIM2 stop in debug
+// </h>
+DbgMCU_APB1L_Fz1 = 0x00000000;
+
+// <h> DBGMCU APB2 peripheral freeze register (DBGMCU_APB2FZ1)
+//                                   <i> Reserved bits must be kept at reset value
+//   <o.29> DBG_HRTIM                <i> HRTIM stop in debug
+//   <o.18> DBG_TIM17                <i> TIM17 stop in debug
+//   <o.17> DBG_TIM16                <i> TIM16 stop in debug
+//   <o.16> DBG_TIM15                <i> TIM15 stop in debug
+//   <o.1>  DBG_TIM8                 <i> TIM8 stop in debug
+//   <o.0>  DBG_TIM1                 <i> TIM1 stop in debug
+// </h>
+DbgMCU_APB2_Fz1 = 0x00000000;
+
+// <h> DBGMCU APB4 peripheral freeze register (DBGMCU_APB4FZ1)
+//                                   <i> Reserved bits must be kept at reset value
+//   <o.18> DBG_IIWDG1               <i> Independent watchdog for D1 stop in debug
+//   <o.16> DBG_RTC                  <i> RTC stop in debug
+//   <o.12> DBG_LPTIM5               <i> LPTIM5 stop in debug
+//   <o.11> DBG_LPTIM4               <i> LPTIM4 stop in debug
+//   <o.10> DBG_LPTIM3               <i> LPTIM2 stop in debug
+//   <o.9>  DBG_LPTIM2               <i> LPTIM2 stop in debug
+//   <o.7>  DBG_I2C4                 <i> I2C4 SMBUS timeout stop in debug
+// </h>
+DbgMCU_APB4_Fz1 = 0x00000000;
+
+// <h> TPIU Pin Routing (TRACECLK fixed on Pin PE2)
+//   <i> TRACECLK: Pin PE2
+//   <o1> TRACED0
+//     <i> ETM Trace Data 0
+//       <0x00040003=> Pin PE3
+//       <0x00020001=> Pin PC1
+//       <0x0006000D=> Pin PG13
+//   <o2> TRACED1
+//     <i> ETM Trace Data 1
+//       <0x00040004=> Pin PE4
+//       <0x00020008=> Pin PC8
+//       <0x0006000E=> Pin PG14
+//   <o3> TRACED2
+//     <i> ETM Trace Data 2
+//       <0x00040005=> Pin PE5
+//       <0x00030002=> Pin PD2
+//   <o4> TRACED3
+//     <i> ETM Trace Data 3
+//       <0x00040006=> Pin PE6
+//       <0x0002000C=> Pin PC12
+// </h>
+TraceClk_Pin = 0x00040002;
+TraceD0_Pin  = 0x00040003;
+TraceD1_Pin  = 0x00040004;
+TraceD2_Pin  = 0x00040005;
+TraceD3_Pin  = 0x00040006;
+
+// <<< end of configuration section >>>


### PR DESCRIPTION
Split the action for preparing the MW-RefApps folder structure into 3 smaller actions to improve readability. 
Split the monolithic build test actions for AC6 and GCC in to a Release and a Debug action.
Added dbgconf files for the Blinky example.
Modified action: Copy Blinky example to CI/Examples/ folder. Copy folder starting with a dot.